### PR TITLE
Add `for` alert property

### DIFF
--- a/src/main/kotlin/ru/yoomoney/tech/grafana/dsl/panels/alerting/Alert.kt
+++ b/src/main/kotlin/ru/yoomoney/tech/grafana/dsl/panels/alerting/Alert.kt
@@ -15,7 +15,8 @@ class Alert(
     private val onNoData: AlertingState = Ok,
     private val onExecutionError: AlertingState = Alerting,
     private val notificationIds: List<Long> = emptyList(),
-    private val conditions: AlertingConditions
+    private val conditions: AlertingConditions,
+    private val pendingFor: Duration = 0.m
 ) : Json<JSONObject> {
 
     override fun toJson(): JSONObject {
@@ -29,6 +30,7 @@ class Alert(
         json["executionErrorState"] = onExecutionError.asState()
         json["notifications"] = JSONArray(notificationIds.map { JSONObject().put("id", it) })
         json["conditions"] = conditions.toJson()
+        json["for"] = pendingFor.toString()
 
         return json
     }

--- a/src/main/kotlin/ru/yoomoney/tech/grafana/dsl/panels/alerting/AlertBuilder.kt
+++ b/src/main/kotlin/ru/yoomoney/tech/grafana/dsl/panels/alerting/AlertBuilder.kt
@@ -10,6 +10,7 @@ class AlertBuilder(private val name: String) {
     var message = ""
     var handler = 1
     var frequency = 1.m
+    var pendingFor = 0.m
     var onNoData = Ok
     var onExecutionError = Alerting
 
@@ -39,7 +40,8 @@ class AlertBuilder(private val name: String) {
                     onNoData = onNoData,
                     onExecutionError = onExecutionError,
                     notificationIds = notificationIds,
-                    conditions = AlertingConditions(conditions)
+                    conditions = AlertingConditions(conditions),
+                    pendingFor = pendingFor
             ),
             thresholds = Thresholds(thresholds)
     )

--- a/src/test/kotlin/ru/yoomoney/tech/grafana/dsl/panels/alerting/AlertBuilderTest.kt
+++ b/src/test/kotlin/ru/yoomoney/tech/grafana/dsl/panels/alerting/AlertBuilderTest.kt
@@ -1,0 +1,45 @@
+package ru.yoomoney.tech.grafana.dsl.panels.alerting
+
+import org.json.JSONObject
+import org.testng.annotations.Test
+import ru.yoomoney.tech.grafana.dsl.jsonFile
+import ru.yoomoney.tech.grafana.dsl.metrics.ReferencedDashboardMetric
+import ru.yoomoney.tech.grafana.dsl.metrics.functions.StringMetric
+import ru.yoomoney.tech.grafana.dsl.shouldEqualToJson
+import ru.yoomoney.tech.grafana.dsl.time.m
+
+class AlertBuilderTest {
+
+    @Test
+    fun `should create alerting panel`() {
+        val builder = AlertBuilder("Alert name").apply {
+            frequency = 5.m
+            pendingFor = 10.m
+
+            message = "Alert message"
+            notificationIds += 1
+            notificationIds += 2
+
+            conditions {
+                query(
+                    ReferencedDashboardMetric(
+                        StringMetric("*"),
+                        "A",
+                        false
+                    ),
+                    15.m
+                ).isAbove(3000)
+            }
+
+            thresholds {
+                threshold { ThresholdDsl.gt(3000) }
+            }
+        }
+
+        val alertingPanelJson = JSONObject()
+            .apply {  builder.createAlertingPanel().invoke(this) }
+            .toString()
+
+        alertingPanelJson shouldEqualToJson jsonFile("AlertingPanel.json")
+    }
+}

--- a/src/test/resources/ru/yoomoney/tech/grafana/dsl/panels/alerting/AlertingPanel.json
+++ b/src/test/resources/ru/yoomoney/tech/grafana/dsl/panels/alerting/AlertingPanel.json
@@ -1,0 +1,52 @@
+{
+  "thresholds": [
+    {
+      "op": "gt",
+      "line": true,
+      "colorMode": "critical",
+      "fill": true,
+      "value": 3000
+    }
+  ],
+  "alert": {
+    "handler": 1,
+    "executionErrorState": "alerting",
+    "name": "Alert name",
+    "for": "10m",
+    "noDataState": "ok",
+    "message": "Alert message",
+    "conditions": [
+      {
+        "query": {
+          "datasourceId": 1,
+          "model": {
+            "hide": false,
+            "target": "*",
+            "refId": "A"
+          },
+          "params": [
+            "A",
+            "15m",
+            "now"
+          ]
+        },
+        "type": "query",
+        "evaluator": {
+          "type": "gt",
+          "params": [
+            3000
+          ]
+        }
+      }
+    ],
+    "notifications": [
+      {
+        "id": 1
+      },
+      {
+        "id": 2
+      }
+    ],
+    "frequency": "5m"
+  }
+}


### PR DESCRIPTION
Алерты в Grafana, начиная с версии 5.4, имеют свойство For: https://grafana.com/docs/grafana/latest/alerting/create-alerts/

В документации по приведённой выше ссылке этот параметр рекомендуется к использованию: "Typically, it’s always a good idea to use this setting"

Добавил соответствующее поле в классы Alert и AlertBuilder.

Так как for является ключевым словом в Kotlin, я назвал новое поле pendingFor. Название обусловлено тем, что алерт находится в состоянии Pending в течение периода pendingFor, прежде чем перейти в состояние Alerting.