### PR TITLE
Add `No data` and `Keep last state` alerting states

### DIFF
--- a/src/main/kotlin/ru/yoomoney/tech/grafana/dsl/panels/alerting/AlertingStates.kt
+++ b/src/main/kotlin/ru/yoomoney/tech/grafana/dsl/panels/alerting/AlertingStates.kt
@@ -7,3 +7,11 @@ object Alerting : AlertingState {
 object Ok : AlertingState {
     override fun asState() = "ok"
 }
+
+object KeepLastState : AlertingState {
+    override fun asState() = "keep_state"
+}
+
+object NoData : AlertingState {
+    override fun asState() = "no_data"
+}

--- a/src/test/kotlin/ru/yoomoney/tech/grafana/dsl/panels/alerting/AlertingStatesTest.kt
+++ b/src/test/kotlin/ru/yoomoney/tech/grafana/dsl/panels/alerting/AlertingStatesTest.kt
@@ -1,0 +1,21 @@
+package ru.yoomoney.tech.grafana.dsl.panels.alerting
+
+import org.amshove.kluent.shouldEqual
+import org.testng.annotations.DataProvider
+import org.testng.annotations.Test
+
+class AlertingStatesTest {
+
+    @Test(dataProvider = "alertingStates")
+    fun `should serialize alerting states correctly`(alertingState: AlertingState, representation: String) {
+        alertingState.asState() shouldEqual representation
+    }
+
+    @DataProvider
+    fun alertingStates() = arrayOf(
+            arrayOf(Alerting, "alerting"),
+            arrayOf(Ok, "ok"),
+            arrayOf(KeepLastState, "keep_state"),
+            arrayOf(NoData, "no_data")
+    )
+}


### PR DESCRIPTION
Добавление недостающих AlertingState. 

Список возможных состояний: https://grafana.com/docs/grafana/latest/alerting/create-alerts/#no-data--error-handling