### PR TITLE
Конкретная версия libraries-project-plugin

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -4,6 +4,6 @@ repositories {
 
     dependencies {
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50'
-        classpath 'ru.yoomoney.gradle.plugins:library-project-plugin:7.+'
+        classpath 'ru.yoomoney.gradle.plugins:library-project-plugin:7.1.2'
     }
 }


### PR DESCRIPTION
прошлый релиз не выпустился, был баг в library-project-plugin.
баг починили, но при сборке релизная джоба берет все ту же версию. даже с refresh-dependencies и чисткой хэша в travis.
https://travis-ci.com/github/yoomoney-tech/grafana-dashboard-dsl/jobs/500718189

не знаю почему, предлагаю поставить конкретную версию, выпустить релиз и вернуть как было, +
